### PR TITLE
Updated README with fixed example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # grunt-replicate
 
 Grunt Task for Replicating Directories
@@ -63,8 +62,8 @@ grunt.initConfig({
             src: "src",
             dest: "out",
             options: {
-                regexExcludeSource: "(?:.*?/)?node_modules(?:/.*)?$",
-                regexExcludeDestination: "(?:.*?/)?\\.(?:git(?:/.*)?|gitignore)$"
+                regexpExcludeSource: "(?:.*?/)?node_modules(?:/.*)?$",
+                regexpExcludeDestination: "(?:.*?/)?\\.(?:git(?:/.*)?|gitignore)$"
             }
         }
     }


### PR DESCRIPTION
The code in the usage example is missing a "p" in "regexp".
