### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,40 +1,42 @@
 {
-    "name":        "grunt-replicate",
-    "homepage":    "http://github.com/rse/grunt-replicate",
+    "name": "grunt-replicate",
+    "homepage": "http://github.com/rse/grunt-replicate",
     "description": "Grunt Task for Replicating Directories",
-    "version":     "0.9.0",
-    "license":     "MIT",
+    "version": "0.9.0",
+    "license": "MIT",
     "author": {
-        "name":    "Ralf S. Engelschall",
-        "email":   "rse@engelschall.com",
-        "url":     "http://engelschall.com"
+        "name": "Ralf S. Engelschall",
+        "email": "rse@engelschall.com",
+        "url": "http://engelschall.com"
     },
     "keywords": [
         "gruntplugin",
-        "replicate", "synchronize", "directory"
+        "replicate",
+        "synchronize",
+        "directory"
     ],
     "repository": {
         "type": "git",
-        "url":  "git://github.com/rse/grunt-replicate.git"
+        "url": "git://github.com/rse/grunt-replicate.git"
     },
     "bugs": {
-        "url":  "http://github.com/rse/grunt-replicate/issues"
+        "url": "http://github.com/rse/grunt-replicate/issues"
     },
     "main": "Gruntfile.js",
     "devDependencies": {
-        "grunt":                "~0.4.1",
-        "grunt-cli":            "~0.1.10",
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.10",
         "grunt-contrib-jshint": "~0.7.2",
-        "grunt-contrib-clean":  "~0.5.0"
+        "grunt-contrib-clean": "~0.5.0"
     },
     "peerDependencies": {
-        "grunt":                "~0.4.1"
+        "grunt": ">=0.4.0"
     },
     "dependencies": {
-        "chalk":                "~0.3.0",
-        "sprintf-js":           "~0.0.7"
+        "chalk": "~0.3.0",
+        "sprintf-js": "~0.0.7"
     },
     "engines": {
-        "node":                 ">=0.10.0"
+        "node": ">=0.10.0"
     }
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
